### PR TITLE
Fix hybrid leakage and document clean 2026 workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,16 @@
 # AFL Tipping
 
-The aim of this repo is to provide a useful resource for AFL tipping. 
-
-The ELO rating script currently calculates an ELO rating for each AFL team.
+This repository contains AFL data pipelines and margin/tipping models, with a walk-forward backtest framework.
 
 ## Setup
 
-This project now uses `uv` for environment and dependency management.
+Install dependencies with `uv`:
 
 ```bash
 uv sync --group dev
 ```
 
-Run tests with:
+Run tests:
 
 ```bash
 uv run pytest -vvrP
@@ -20,60 +18,181 @@ uv run pytest -vvrP
 
 ## Data
 
-The data used is taken from here
+Primary historical data source:
 
-https://www.kaggle.com/datasets/stoney71/aflstats
+- https://www.kaggle.com/datasets/stoney71/aflstats
 
-## Resources Used
+Generated files used by the models:
 
-These kaggle resources outline how to perform an ELO rating
+- `src/outputs/afl_data.csv`: match-level history (scores, goals/behinds, scoring shots)
+- `src/outputs/afl_player_stats.csv`: player-level match stats from AFL Tables scraping
 
-- https://www.kaggle.com/code/kplauritzen/elo-ratings-in-python/notebook
-- https://www.kaggle.com/code/andreiavadanei/elo-predicting-against-dataset
+## Backtesting Pipeline
 
-## Future
-
-- add matchup predictions
-- automate data collection for each round
-- automate predictions 
-- receive predictions via email
-- add machine learning to better predict fixture outcomes
-- add features for players, so we can take into account injuries etc
-
-## MAE Backtesting (Team + Lineups)
-
-A walk-forward MAE pipeline is now available in `src/mae_model/`:
-
-- `src/mae_model/sequential_margin.py`:
-  - team offense/defense sequential ratings
-  - optional lineup/player effects from per-match player stats
-  - scoring-shots variant (using goals + behinds volume)
-  - season carryover and home-advantage updates
-- `src/mae_model/run_backtest.py`:
-  - runs `team_only`, `team_plus_lineup`, and `scoring_shots` backtests
-  - writes:
-    - `reports/walk_forward_predictions.csv`
-    - `reports/mae_summary.csv`
-
-Example:
+Run the walk-forward backtest:
 
 ```bash
 uv run python -m src.mae_model.run_backtest \
   --matches-csv src/outputs/afl_data.csv \
   --lineups-csv src/outputs/afl_player_stats.csv \
+  --output-dir reports_rethink \
   --min-train-years 3
 ```
 
-To generate lineups/player stats from AFL Tables, use:
+Outputs:
 
-```python
-from src.scrape_afl import scrape_tables
-scrape_tables.write_data_to_csv(
-    matches_csv_name="src/outputs/afl_data.csv",
-    players_csv_name="src/outputs/afl_player_stats.csv",
-)
+- `reports_rethink/walk_forward_predictions.csv`
+- `reports_rethink/mae_summary.csv`
+
+## Model Family (Current)
+
+The backtest currently evaluates four models in `src/mae_model/sequential_margin.py`:
+
+1. `team_only`
+- Sequential team offense/defense ratings updated every match.
+- Home advantage and season carryover are applied.
+- Uses only match metadata available pre-game (teams, venue/home status).
+
+2. `team_plus_lineup`
+- Same team engine as `team_only`.
+- Adds player-rating aggregation from lineup rows.
+
+3. `scoring_shots`
+- Predicts scoring-shot volume first, then maps to scores via points-per-shot history.
+- Also sequential with season carryover.
+
+4. `team_residual_lineup`
+- Hybrid decomposition model (`ShotVolumeConversionModel`) that combines scoring-shot volume and conversion effects with lineup conversion ratings.
+
+## Deep Audit (Assumptions, Leakage, Overfit)
+
+Audit run date: **February 7, 2026**.
+
+### What passed
+
+- Walk-forward temporal ordering is respected: models are updated sequentially and only scored after warm-up years.
+- Probability calibration for bits uses prior years only, not the target year.
+- No global scaler/PCA/imputer leakage paths exist in the current code.
+
+### What failed (important)
+
+1. **Hard leakage in `team_residual_lineup`**
+- In `ShotVolumeConversionModel.predict`, the model directly reads `home_scoring_shots` and `away_scoring_shots` from the same match row being predicted.
+- Those values are post-game outcomes, not pre-game inputs.
+- If shots are missing, fallback uses `home_score / 5` and `away_score / 5`, which are even more direct post-game outcomes.
+
+2. **Feature availability mismatch in lineup weighting**
+- Lineup effects use `percent_played` and fallback `disposals` from the same match lineup rows.
+- These are in-game/post-game stats and are not available pre-bounce.
+
+### Quantitative leakage evidence
+
+Using the same dataset and walk-forward setup (`min_train_years=3`):
+
+- Baseline reported `team_residual_lineup`: **MAE 14.5606**, **tip 84.90%**
+- Same model with **no lineup file at all**: **MAE 14.5575**, **tip 84.90%** (nearly unchanged)
+- Same model with `home_scoring_shots=away_scoring_shots=0` forcing score fallback: **MAE 0.5677**, **tip 99.11%**
+
+This confirms the extreme performance is leakage-driven, not true pre-game predictive signal.
+
+### Overfit assessment
+
+- Deployable models (`team_only`, `scoring_shots`) are much closer together and stable year-to-year (overall MAE around 27; 2024-2025 MAE around 26.3-26.9).
+- The hybrid model's large gap versus all other models is inconsistent with realistic AFL tipping uplift and is explained by leakage above.
+
+## Which Model To Use For 2026
+
+For **pre-game 2026 predictions**, treat `team_residual_lineup` as **not deployable** until leakage is removed.
+
+Recommended production baseline:
+
+- **Primary:** `team_only`
+- **Secondary challenger:** `scoring_shots`
+
+Current walk-forward all-years summary:
+
+- `team_only`: MAE 27.3178, tip 67.85%
+- `scoring_shots`: MAE 27.2705, tip 67.80%
+- `team_plus_lineup`: MAE 27.3877, tip 67.71%
+- `team_residual_lineup`: MAE 14.5606, tip 84.90% (**invalid for pre-game use**)
+
+## 2026 Prediction Workflow
+
+Use this weekly cycle during the 2026 season:
+
+1. Update history through the latest completed round.
+- Refresh `src/outputs/afl_data.csv` (and optionally player stats).
+
+2. Re-run backtest as a safety check.
+
+```bash
+uv run python -m src.mae_model.run_backtest \
+  --matches-csv src/outputs/afl_data.csv \
+  --lineups-csv src/outputs/afl_player_stats.csv \
+  --output-dir reports_rethink \
+  --min-train-years 3
 ```
 
-`src/outputs/afl_data.csv` now includes:
-- `home_goals`, `home_behinds`, `home_scoring_shots`
-- `away_goals`, `away_behinds`, `away_scoring_shots`
+3. Generate next-round margins with `team_only` from current model state.
+- Replay all completed historical matches with `model.step(...)`.
+- For upcoming fixtures, call `model.predict(...)` (do not update state until results are known).
+
+Example script:
+
+```python
+import csv
+from src.mae_model.sequential_margin import (
+    MatchRow,
+    SequentialMarginModel,
+    canonical_team_name,
+    load_matches_csv,
+    parse_match_date,
+    round_sort_value,
+)
+
+history = load_matches_csv("src/outputs/afl_data.csv")
+
+fixtures = []
+with open("fixtures_2026_roundN.csv", newline="") as f:
+    for row in csv.DictReader(f):
+        fixtures.append(
+            MatchRow(
+                match_id=row["match_id"],
+                year=int(row["year"]),
+                round_label=row["round"],
+                date=parse_match_date(row["date"]),
+                venue=row.get("venue", ""),
+                home_team=canonical_team_name(row["home_team_name"]),
+                away_team=canonical_team_name(row["away_team_name"]),
+                home_score=0.0,
+                away_score=0.0,
+            )
+        )
+
+model = SequentialMarginModel(
+    use_lineups=False,
+    base_score=76.0,
+    home_advantage=3.0,
+    team_k=0.05,
+    defense_k=0.08,
+    season_carryover=0.78,
+    home_adv_k=0.0,
+)
+
+for m in sorted(history, key=lambda r: (r.date, r.year, round_sort_value(r.round_label), r.match_id)):
+    model.step(m, {})
+
+for fx in sorted(fixtures, key=lambda r: (r.date, r.year, round_sort_value(r.round_label), r.match_id)):
+    _, _, margin = model.predict(fx, {})
+    p_home = 1.0 / (1.0 + __import__("math").exp(-margin / 30.0))
+    print(f"{fx.match_id},{fx.home_team} vs {fx.away_team},pred_margin={margin:.2f},home_win_prob={p_home:.3f}")
+```
+
+4. After round completion, append actual results and replay to update state before the next round.
+
+## Guardrails For Future Model Changes
+
+- Never use same-match post-game fields (`score`, `goals`, `behinds`, `scoring_shots`, `percent_played`, `disposals`) inside `predict(...)`.
+- Keep train/validation strictly walk-forward.
+- Treat test performance as one-time evaluation, not a tuning loop.
+- If performance looks unusually strong, run leakage ablations before accepting it.

--- a/agent_notes/2026-02-07_team-residual-lineup-leakage-fix.md
+++ b/agent_notes/2026-02-07_team-residual-lineup-leakage-fix.md
@@ -1,0 +1,117 @@
+# Team Residual Lineup Leakage Fix
+
+Date: 2026-02-07
+Branch: `jamesfricker/fix-model-leak`
+
+## Request
+Patch `team_residual_lineup` to remove leakage and make it pre-game deployable, then compare stats before vs after.
+
+## Implementation Log
+
+1. Captured pre-patch baseline metrics from `reports_rethink/mae_summary.csv`.
+2. Reviewed `ShotVolumeConversionModel` in `src/mae_model/sequential_margin.py`.
+3. Removed leakage paths in `predict()`:
+- `predict()` no longer consumes same-match `home_scoring_shots` / `away_scoring_shots`.
+- `predict()` now estimates shot volume from model state only (team attack/defense shots + home advantage).
+- lineup conversion effect no longer uses same-match in-game stats (`percent_played`, `disposals`) as weights.
+4. Kept post-game updates in `update()` (allowed), including:
+- updating shot states from actual scoring shots after results are known;
+- updating conversion states from actual points-per-shot after results are known;
+- updating player conversion ratings from goals/behinds after results are known.
+5. Added regression test to lock behavior:
+- `test_hybrid_predict_does_not_use_same_match_outcomes` ensures changing same-match scores/shots does not alter hybrid pre-game prediction.
+6. Re-ran tests and full backtest for post-patch metrics.
+
+## Files Changed
+
+- `src/mae_model/sequential_margin.py`
+- `tests/test_sequential_margin_model.py`
+
+## Key Model Changes (Technical)
+
+### `ShotVolumeConversionModel` initialization
+Added explicit shot-volume state/params:
+- `base_scoring_shots`
+- `home_adv_scoring_shots`
+- `shot_k`
+- `shot_residual_cap`
+- state dictionaries: `team_attack_shots`, `team_defense_shots`
+
+### `predict()` now uses only pre-game-available state
+Old behavior:
+- used match row scoring shots (`home_scoring_shots`, `away_scoring_shots`) inside prediction.
+
+New behavior:
+- predicts scoring shots from historical team shot ratings;
+- predicts conversion (points per shot) from league/team/player conversion state;
+- combines predicted shot volume and predicted conversion for expected margin.
+
+### `update()` now trains two residual channels
+- shot residuals update shot attack/defense ratings;
+- conversion residuals update conversion attack/defense ratings;
+- player conversion ratings updated from post-game player goals/behinds.
+
+### Seasonal transition
+Now re-centers and carries both shot and conversion states.
+
+## Validation Results
+
+### Tests
+Command:
+
+```bash
+uv run pytest -q
+```
+
+Result:
+
+- `14 passed in 2.40s`
+
+### Backtest rerun
+Command:
+
+```bash
+uv run python -m src.mae_model.run_backtest \
+  --matches-csv src/outputs/afl_data.csv \
+  --lineups-csv src/outputs/afl_player_stats.csv \
+  --output-dir .context/leak_fix_reports \
+  --min-train-years 3
+```
+
+## Metrics Comparison (Pre vs Post)
+
+Source files:
+- pre: `reports_rethink/mae_summary.csv`
+- post: `.context/leak_fix_reports/mae_summary.csv`
+
+### ALL years summary
+
+- `scoring_shots`: MAE `27.2705 -> 27.2705`, tip% `67.80 -> 67.80`, bits/game `0.1487 -> 0.1487`
+- `team_only`: MAE `27.3178 -> 27.3178`, tip% `67.85 -> 67.85`, bits/game `0.1434 -> 0.1434`
+- `team_plus_lineup`: MAE `27.3877 -> 27.3877`, tip% `67.71 -> 67.71`, bits/game `0.1418 -> 0.1418`
+- `team_residual_lineup`: MAE `14.5606 -> 27.2271`, tip% `84.90 -> 68.11`, bits/game `0.5278 -> 0.1480`
+
+### Interpretation
+
+- Non-hybrid models are unchanged, as expected.
+- Hybrid model dropped from unrealistically strong performance to parity with deployable baselines.
+- This confirms previous uplift was leakage-driven and that the patched hybrid is now consistent with plausible out-of-sample AFL tipping performance.
+
+## By-Year Hybrid Change (`team_residual_lineup`)
+
+- 2015: MAE `16.2094 -> 31.0973`, tip% `86.41 -> 69.42`
+- 2016: MAE `15.2843 -> 30.4808`, tip% `85.51 -> 70.53`
+- 2017: MAE `15.0059 -> 29.1191`, tip% `83.57 -> 63.77`
+- 2018: MAE `13.8500 -> 26.7463`, tip% `87.44 -> 71.98`
+- 2019: MAE `14.8842 -> 27.0366`, tip% `87.92 -> 63.29`
+- 2020: MAE `13.6889 -> 23.3652`, tip% `85.80 -> 66.67`
+- 2021: MAE `13.6330 -> 27.1875`, tip% `84.54 -> 67.63`
+- 2022: MAE `14.0797 -> 24.4752`, tip% `85.02 -> 71.98`
+- 2023: MAE `14.6979 -> 26.1630`, tip% `82.87 -> 70.37`
+- 2024: MAE `14.9446 -> 26.8232`, tip% `81.94 -> 62.50`
+- 2025: MAE `13.7211 -> 26.2875`, tip% `83.33 -> 70.83`
+
+## Remaining Caveats
+
+- Backtest still uses historical lineups keyed by match id; this is acceptable for research but assumes lineup lists are known pre-game in production.
+- `team_plus_lineup` still uses same-match `percent_played`/`disposals` weighting and remains not strictly pre-game-safe unless similarly patched.


### PR DESCRIPTION
This removes leakage from the hybrid team_residual_lineup model by preventing same-match outcome fields from being used in predict(). It adds a regression test to ensure hybrid predictions do not change when same-match scores/scoring shots are modified. The README now includes a detailed leakage audit and a pre-game-safe 2026 prediction workflow. Backtests and tests were rerun and are included in the notes.