### PR TITLE
Add lineup-aware pregame market modeling

### DIFF
--- a/agent_notes/2026-02-08-lineup-market-feature-integration.md
+++ b/agent_notes/2026-02-08-lineup-market-feature-integration.md
@@ -1,0 +1,74 @@
+# Lineup + Rich Market Feature Integration Experiment (2026-02-08)
+
+## Goal
+Test whether adding:
+1) pregame-known lineup structure signals,
+2) richer market fields (open/min/max lines, totals, movement),
+can improve the current best market-anchored model path.
+
+## Scope of code changes
+Primary file:
+- `src/mae_model/sequential_margin.py`
+
+Implemented:
+- Added `KnownLineupTracker` to derive pregame lineup features without leakage.
+  - `lineup_known_diff`
+  - `lineup_returning_diff`
+  - `lineup_debut_diff`
+  - `lineup_size_diff`
+  - `lineup_volatility`
+- Expanded `load_market_xlsx()` ingestion beyond close line/odds:
+  - line open/min/max
+  - odds open/close
+  - totals open/min/max/close
+  - bookmakers surveyed
+- Fed these new features into:
+  - `_internal_adjustment_features`
+  - `_market_anchor_features`
+  - `_market_residual_features`
+  - `_market_residual_meta_features`
+- Extended residual safety damping with:
+  - `line_move_k`
+  - `lineup_k`
+- Wired lineup tracker + rich market row fields through `walk_forward_predictions()`.
+
+## Validation
+- `uv run python -m py_compile src/mae_model/sequential_margin.py` -> pass
+- `uv run pytest tests/test_sequential_margin_model.py -q` -> pass
+- `uv run pytest -q` -> pass (31)
+
+## Backtest
+Command:
+- `PYTHONWARNINGS=ignore uv run python -m src.mae_model.run_backtest --output-dir .context/reports_improved_lineup_market`
+
+## Comparison vs prior branch baseline (`.context/reports_rework`)
+
+### market_line_blend
+- 2025: 26.2158 -> **26.1864** (improved by 0.0294)
+- ALL: 26.6412 -> **26.6690** (worse by 0.0278)
+
+### market_residual_corrector
+- 2025: 26.0815 -> **26.1211** (worse by 0.0396)
+- ALL: 26.6586 -> **26.7143** (worse by 0.0557)
+
+### market_only
+- 2025: 26.1944 -> **26.1944** (no change)
+- ALL: 26.6466 -> **26.6466** (no change)
+
+### side/internal diagnostic
+- `team_residual_lineup_form` 2025: 26.2998 -> **26.2890** (small improvement)
+
+## Decision
+Result is mixed and does **not** improve the strongest path consistently:
+- slight 2025 improvement for `market_line_blend`,
+- but regression on `market_residual_corrector` and overall MAE.
+
+So this integration is not a clear upgrade yet.
+
+## Likely reason
+The expanded feature set adds variance and appears to overfit older-year residual dynamics; lineup context and line-movement effects are not robust enough under current year-locked stacking/safety settings.
+
+## Next iteration ideas
+1. Keep rich market + lineup features only in anchor model, revert residual feature expansion.
+2. Add strong feature shrinkage / stability filtering before residual stack fitting.
+3. Restrict new signals to a learned gate (when to correct) instead of direct residual magnitude prediction.

--- a/agent_notes/2026-02-08-lineup-strength-v2.md
+++ b/agent_notes/2026-02-08-lineup-strength-v2.md
@@ -1,0 +1,65 @@
+# Lineup Strength V2 Experiment (2026-02-08)
+
+## Objective
+Attempt to improve the best market-anchored model by using stronger pregame lineup information (known 22) plus existing market/context fields already in dataset.
+
+## Hypothesis
+A player-quality-weighted lineup strength signal, computed strictly from prior matches, should help anchor/residual corrections when market and internal disagree.
+
+## Changes made
+File: `src/mae_model/sequential_margin.py`
+
+1. Added `LineupStrengthTracker`
+- Tracks per-player historical impact from prior games only.
+- Impact uses available player stats (`disposals`, `goals`, `behinds`, `clearances`, `tackles`, `inside_50s`, `contested_possessions`, `marks`, `goal_assists`) with TOG weighting.
+- Produces pregame team-level features:
+  - `lineup_strength_diff`
+  - `lineup_experience_diff`
+  - `lineup_top_end_diff`
+
+2. Integrated lineup strength into pregame feature flow
+- `walk_forward_predictions()` now updates pregame feature map with lineup strength tracker output before prediction.
+- Tracker updates only after each match to preserve temporal integrity.
+
+3. Rebalanced feature sets to reduce overfit risk
+- Simplified market anchor and residual feature vectors relative to prior over-expanded variant.
+- Kept a compact set of movement/total/context and lineup terms.
+
+4. Safety/fit compatibility
+- Updated anchor default coefficient dimension to align with new feature vector.
+
+## Validation
+- `uv run python -m py_compile src/mae_model/sequential_margin.py` -> pass
+- `uv run pytest tests/test_sequential_margin_model.py -q` -> pass
+- `uv run pytest -q` -> pass (31 tests)
+
+## Backtest run
+Command:
+- `PYTHONWARNINGS=ignore uv run python -m src.mae_model.run_backtest --output-dir .context/reports_lineup_strength_v2`
+
+## Results
+Compared with prior run (`.context/reports_improved_lineup_market`) and strongest earlier run (`.context/reports_rework`):
+
+### market_line_blend
+- lineup_market: 2025 = 26.1864, ALL = 26.6690
+- lineup_strength_v2: 2025 = 26.2153, ALL = 26.6801
+- delta: worse on both
+
+### market_residual_corrector
+- lineup_market: 2025 = 26.1211, ALL = 26.7143
+- lineup_strength_v2: 2025 = 26.2274, ALL = 26.7348
+- delta: worse on both
+
+### strongest earlier run (reference)
+- rework: market_residual_corrector 2025 = 26.0815, ALL = 26.6586
+- lineup_strength_v2 is below this benchmark.
+
+## Decision
+This variant does not improve the best model; it regresses key metrics.
+
+## Interpretation
+The current lineup-strength signal adds noise under year-locked evaluation, likely because player-impact estimation from box score aggregates is not stable enough in this form and/or is redundant with market adjustment features.
+
+## Next recommended direction
+- Keep lineup signals only in a *gate* (when to correct), not in correction magnitude.
+- Revert residual feature set toward the stronger `reports_rework` configuration and add only 1-2 lineup confidence features with very strong shrinkage.

--- a/agent_notes/2026-02-08-mae24-feasibility.md
+++ b/agent_notes/2026-02-08-mae24-feasibility.md
@@ -1,0 +1,83 @@
+# MAE 24.0 Feasibility Check (2025)
+
+## Question
+Is 2025 MAE ~= 24 achievable with current data and modeling approach?
+
+## Baseline numbers (from `.context/reports_baseline_check/mae_summary.csv`)
+- market_only 2025 MAE: **26.1944**
+- market_line_blend 2025 MAE: **26.0380**
+- market_residual_corrector 2025 MAE: **26.0729**
+
+Gap to target 24.0 from best baseline = **2.038 points/game**.
+Across 216 games, this is ~**440 absolute-error points** to remove.
+
+## Data quality / available market fields
+Checked `src/outputs/afl_betting_history.xlsx`:
+- Current loader uses only: `Home Line Close`, `Home Odds`, `Away Odds`.
+- Workbook also contains richer fields: open/min/max lines, totals open/close/min/max, line/total odds and other close/open columns.
+- 2025 market close coverage appears full in joined backtest rows (216 games).
+
+## Experiments run
+All experiments were run as strict train(<2025) -> test(2025), unless explicitly labeled oracle/in-sample.
+
+### 1) Market-only anchor variants using richer market columns
+- market_close MAE: **26.1944**
+- market_open MAE: **26.2269**
+- avg(open,close) MAE: **26.1204**
+
+No meaningful improvement toward 24.
+
+### 2) Direct market-feature models (train<2025, test2025)
+Features included close/open/min/max line, odds (open/close), totals (open/close/min/max), and movement-derived terms.
+- Ridge MAE: **26.1479**
+- Huber MAE: **26.1881**
+- HistGradientBoosting (MAE loss) MAE: **26.4115**
+
+Best was still around 26.15.
+
+### 3) Constrained residual correction from market_close
+Huber residual model + cap/scale search on correction:
+- best MAE: **26.1369**
+
+Still far from 24.
+
+### 4) Gated-correction stress test using model disagreement + market context
+Using baseline predictions + market movement/odds/totals as gating/correction features:
+- Best residual-corrector setup: **26.0551**
+- Trainable hard gate (choose anchor vs corrected): **26.0401**
+- Trainable soft gate: **26.0375** (essentially unchanged vs anchor 26.0380)
+
+So learned gating did not unlock large gains under year-locked training.
+
+### 5) Upper/lower-bound diagnostics
+- Oracle choose-better-per-game between anchor and one learned corrector: **25.3440**
+- Oracle linear blend trained on 2025 itself (not valid OOS):
+  - Ridge in-sample MAE: **25.8173**
+  - Quantile in-sample MAE: **25.4006**
+
+Interpretation: even optimistic in-sample linear methods with current fields do not approach 24.
+
+### 6) Within-2025 CV check (signal sanity)
+5-fold CV on 2025 only with market-rich features:
+- Ridge CV MAE: **27.4291**
+- Quantile CV MAE: **28.0759**
+- HGB CV MAE: **27.8856**
+
+This indicates weak stable within-season predictive signal beyond the close line itself.
+
+## Feasibility conclusion
+With the **current effective information set** (current match data + available market workbook fields) and strict year-locked setup, reaching **2025 MAE ~24.0** appears **not realistically achievable**.
+
+Evidence:
+- Best robust out-of-sample results remain clustered around **26.0-26.2**.
+- Large required improvement (2+ points/game) is not recovered by richer market engineering or learned gating under temporal discipline.
+
+## What would likely be required to approach 24
+1. Stronger market anchor inputs than currently exploited/available in model ingestion:
+   - true multi-book consensus close at timestamped final line,
+   - exchange/price depth features,
+   - explicit line movement time series (not just open-close delta).
+2. High-value external pre-game signals not currently represented strongly enough:
+   - late outs/injury confirmations,
+   - high-quality weather + venue effects tied to kickoff timing.
+3. Distributional modeling of market (median-optimal inference) instead of point-line correction, likely with richer market microstructure data.

--- a/agent_notes/2026-02-08-market-residual-redesign.md
+++ b/agent_notes/2026-02-08-market-residual-redesign.md
@@ -1,0 +1,149 @@
+# Market Residual Corrector Redesign Log (2026-02-08)
+
+## Objective
+Reduce MAE for `market_residual_corrector` while preserving walk-forward and year-locked training discipline.
+
+## Starting Point
+- Baseline run command: `uv run python -m src.mae_model.run_backtest --output-dir .context/reports_baseline_check`
+- Baseline overall MAE:
+  - `market_residual_corrector`: `26.5515`
+- Baseline yearly (focus years):
+  - 2020: 22.5964
+  - 2021: 26.8034
+  - 2022: 24.1076
+  - 2023: 25.1730
+  - 2024: 26.6748
+  - 2025: 26.0729
+- Benchmarks to beat:
+  - 2020: 27.82
+  - 2021: 27.82
+  - 2022: 26.48
+  - 2023: 26.48
+  - 2024: 26.36
+  - 2025: 25.97
+
+## Key Decisions and Rationale
+
+1. Added pre-game engineered state tracking (`TeamFeatureTracker`)
+- Why: Need richer internal and disagreement context features without leakage.
+- Added:
+  - EWMA margin form (alpha 0.1/0.3/0.5)
+  - rolling margin means (3/5/10)
+  - rest day features (short rest, long break)
+  - travel/interstate proxies via venue/team geography mapping
+  - season progression scalar
+- Leakage control: all features are queried pre-match, then tracker updates after match.
+
+2. Added disagreement context reliability tracker (`DisagreementReliabilityTracker`)
+- Why: disagreement signal should be context-dependent and historically calibrated.
+- Added smoothed context hit-rate by:
+  - finals/regular
+  - disagreement bucket
+  - favourite + sigma uncertainty bucket
+- Used as model feature and damping signal.
+
+3. Upgraded internal margin component with learned pre-game adjuster
+- Why: improve `team_residual_lineup` component before market anchoring.
+- Implemented `_fit_internal_margin_adjuster` / `_apply_internal_margin_adjuster`:
+  - ridge over form/rest/travel features
+  - target-encoded venue residual effect with shrinkage
+  - year-locked fitting from prior seasons only
+
+4. Upgraded market anchor from fixed weight blend to adaptive anchor model
+- Why: fixed blend cannot adapt across uncertainty/disagreement contexts.
+- Implemented `_fit_market_anchor_model` / `_apply_market_anchor_model`:
+  - anchor adjustment trained on `actual - market_margin`
+  - features include market/base/internal disagreement and context terms
+  - adaptive damping and clipping tuned by validation MAE
+
+5. Replaced linear residual corrector with stacked residual ensemble
+- Why: current correction was too linear for disagreement regimes.
+- Implemented:
+  - richer residual features (non-linear disagreement terms, bins, interactions, phase, uncertainty, reliability)
+  - base learners: Ridge, Huber, HistGradientBoosting
+  - chronological OOF stacking for meta-learner
+  - optional isotonic calibration when it improves OOF MAE materially
+
+6. Implemented adaptive safety controls
+- Why: fixed caps/damping are too rigid.
+- Added:
+  - context quantile caps by finals/disagreement/sigma buckets
+  - model-based expected residual magnitude (`abs_model`) for cap adaptation
+  - damping driven by sigma, disagreement magnitude, and disagreement reliability
+  - tuned post-correction scale (`post_scale`) to reduce over-correction in late years
+
+7. Preserved walk-forward/year-locked discipline end-to-end
+- Year-level configs (`internal`, `anchor`, `residual`) are fit only from prior seasons.
+- Feature trackers and reliability state are updated only after prediction.
+
+## Implementation Notes
+
+Main file changed:
+- `src/mae_model/sequential_margin.py`
+
+Core integration points:
+- New feature trackers and venue/travel utilities near top of file.
+- New internal adjuster around `_fit_internal_margin_adjuster`.
+- New adaptive anchor around `_fit_market_anchor_model`.
+- New stacked residual/safety around `_fit_market_residual_corrector`.
+- `walk_forward_predictions` now orchestrates:
+  1) pre-game features,
+  2) internal adjustment,
+  3) adaptive anchor,
+  4) stacked residual correction,
+  5) tracker updates.
+
+Also added diagnostic model output:
+- `team_residual_lineup_form`
+
+## Experiment Iterations
+
+### Iteration 1 (full redesign)
+- Result (`.context/reports_rework`):
+  - `market_residual_corrector` overall: `26.7120`
+  - 2024: `26.5119`
+  - 2025: `26.0931`
+- Interpretation:
+  - Better than baseline on 2024.
+  - Slightly worse than baseline on 2025.
+  - Still above benchmark in 2024/2025.
+
+### Iteration 2 (runtime + safety cache + reduced grid)
+- Added cached raw residual predictions in safety search.
+- Reduced tuning grid and removed heavy warning-producing RF path.
+- Result:
+  - `market_residual_corrector` overall: `26.6586`
+  - 2024: `26.5577`
+  - 2025: `26.0815`
+- Interpretation:
+  - Net small improvement vs Iteration 1.
+  - 2024 improved materially vs baseline, but still above benchmark.
+  - 2025 still just above benchmark.
+
+## Runtime/Engineering Tradeoffs
+
+- Initial advanced grid was too slow; killed and reduced search complexity.
+- Added prediction caching in safety tuning to avoid repeated model inference during grid evaluation.
+- Removed RF base model due runtime/noise overhead in this environment; retained diverse model family via linear + robust linear + boosted tree.
+- Kept full walk-forward training semantics intact despite optimization.
+
+## Validation
+
+- `uv run pytest tests/test_sequential_margin_model.py -q` -> pass
+- `uv run pytest -q` -> pass (31 tests)
+- Backtests executed multiple times with outputs in `.context/reports_rework`.
+
+## Current Status vs Benchmarks
+
+- Benchmarks beaten for: 2020, 2021, 2022, 2023.
+- Benchmarks not yet beaten for: 2024, 2025.
+- Gap remaining:
+  - 2024: `26.5577` vs target `26.36` (gap +0.1977)
+  - 2025: `26.0815` vs target `25.97` (gap +0.1115)
+
+## Next candidate improvements (not yet implemented)
+
+1. Add explicit dual-corrector ensemble: legacy ridge corrector + stacked corrector with year-locked blend weight tuning.
+2. Separate late-season/finals residual experts with gating by round phase.
+3. Add robust feature stability filtering across folds (drop unstable interaction terms) before fitting each year.
+4. Use rolling calibration (last N prior rounds) for correction scale in-season.

--- a/agent_notes/2026-02-08-pr-creation.md
+++ b/agent_notes/2026-02-08-pr-creation.md
@@ -1,0 +1,13 @@
+# PR creation notes (2026-02-08)
+
+## Context
+- User requested opening a PR from the current working state.
+- Current diff includes the sequential margin model rework plus four prior investigation notes.
+
+## Decisions
+- Keep all current tracked and untracked changes together in one commit to preserve the exact state the user approved.
+- Run full tests before PR creation to confirm no regressions in this snapshot.
+- Use a concise PR title focused on lineup + market pregame enhancements.
+
+## Validation
+- `uv run pytest -q` passed: 31 passed.


### PR DESCRIPTION
This PR adds a substantial rework of src/mae_model/sequential_margin.py to incorporate richer pregame context, including lineup-derived signals, expanded market fields, and updated market anchor/residual correction flows.
It also adds experiment notes in agent_notes/ documenting decisions, tests, and backtest outcomes.
Validation run: uv run pytest -q (31 passed).
